### PR TITLE
Add liveview folder locations to Projectionist

### DIFF
--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -40,6 +40,24 @@ local config = {
         "end",
       },
     },
+    ["lib/**/live/*_live.ex"] = {
+      type = "liveview",
+      alternate = "test/{dirname}/live/{basename}_live.exs",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Live do",
+        "  use {dirname|camelcase|capitalize}, :live_view",
+        "end",
+      },
+    },
+    ["test/**/live/*_live.exs"] = {
+      type = "test",
+      alternate = "lib/{dirname}/live/{basename}_live.ex",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}LiveTest do",
+        "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
+        "end",
+      },
+    },
     ["lib/**/channels/*_channel.ex"] = {
       type = "channel",
       alternate = "test/{dirname}/channels/{basename}_channel_test.exs",

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -62,6 +62,26 @@ local config = {
         "end",
       },
     },
+    ["lib/**/components/*_component.ex"] = {
+      type = "component",
+      alternate = "test/{dirname}/components/{basename}_component_test.exs",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Component do",
+        "  use Phoenix.Component",
+        "end",
+      },
+    },
+    ["test/**/controllers/*_component_test.exs"] = {
+      type = "test",
+      alternate = "lib/{dirname}/components/{basename}_component.ex",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ComponentTest do",
+        "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
+        "",
+        "  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Component",
+        "end",
+      },
+    },
     ["lib/**/live/*_live.ex"] = {
       type = "liveview",
       alternate = "test/{dirname}/live/{basename}_live_test.exs",

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -12,8 +12,8 @@ local config = {
       },
     },
     ["test/**/views/*_view_test.exs"] = {
-      alternate = "lib/{dirname}/views/{basename}_view.ex",
       type = "test",
+      alternate = "lib/{dirname}/views/{basename}_view.ex",
       template = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ViewTest do",
         "  use ExUnit.Case, async: true",
@@ -32,8 +32,8 @@ local config = {
       },
     },
     ["test/**/controllers/*_controller_test.exs"] = {
-      alternate = "lib/{dirname}/controllers/{basename}_controller.ex",
       type = "test",
+      alternate = "lib/{dirname}/controllers/{basename}_controller.ex",
       template = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ControllerTest do",
         "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
@@ -68,8 +68,8 @@ local config = {
       },
     },
     ["test/**/channels/*_channel_test.exs"] = {
-      alternate = "lib/{dirname}/channels/{basename}_channel.ex",
       type = "test",
+      alternate = "lib/{dirname}/channels/{basename}_channel.ex",
       template = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ChannelTest do",
         "  use {dirname|camelcase|capitalize}.ChannelCase, async: true",
@@ -87,13 +87,13 @@ local config = {
       },
     },
     ["lib/*.ex"] = {
-      alternate = "test/{}_test.exs",
       type = "source",
+      alternate = "test/{}_test.exs",
       template = { "defmodule {camelcase|capitalize|dot} do", "end" },
     },
     ["test/*_test.exs"] = {
-      alternate = "lib/{}.ex",
       type = "test",
+      alternate = "lib/{}.ex",
       template = {
         "defmodule {camelcase|capitalize|dot}Test do",
         "  use ExUnit.Case, async: true",

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -47,7 +47,7 @@ local config = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}HTML do",
         "  use {dirname|camelcase|capitalize}, :html",
         "",
-        "  embed_templates {basename|snake_case}_html/*",
+        [[  embed_templates "{basename|snakecase}_html/*"]],
         "end",
       },
     },

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -55,7 +55,7 @@ local config = {
       type = "test",
       alternate = "lib/{dirname}/controllers/{basename}_html.ex",
       template = {
-        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ControllerTest do",
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}HTMLTest do",
         "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
         "",
         "  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}HTML",

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -49,7 +49,7 @@ local config = {
         "end",
       },
     },
-    ["test/**/live/*_live.exs"] = {
+    ["test/**/live/*_live_test.exs"] = {
       type = "test",
       alternate = "lib/{dirname}/live/{basename}_live.ex",
       template = {

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -96,7 +96,9 @@ local config = {
       alternate = "lib/{dirname}/live/{basename}_live.ex",
       template = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}LiveTest do",
-        "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
+        "  use {dirname|camelcase|capitalize}.ConnCase",
+        "",
+        "  import Phoenix.LiveViewTest",
         "end",
       },
     },

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -62,23 +62,23 @@ local config = {
         "end",
       },
     },
-    ["lib/**/components/*_component.ex"] = {
+    ["lib/**/components/*.ex"] = {
       type = "component",
-      alternate = "test/{dirname}/components/{basename}_component_test.exs",
+      alternate = "test/{dirname}/components/{basename}_test.exs",
       template = {
-        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Component do",
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize} do",
         "  use Phoenix.Component",
         "end",
       },
     },
-    ["test/**/controllers/*_component_test.exs"] = {
+    ["test/**/controllers/*_test.exs"] = {
       type = "test",
-      alternate = "lib/{dirname}/components/{basename}_component.ex",
+      alternate = "lib/{dirname}/components/{basename}.ex",
       template = {
-        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ComponentTest do",
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Test do",
         "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
         "",
-        "  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Component",
+        "  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}",
         "end",
       },
     },

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -42,7 +42,7 @@ local config = {
     },
     ["lib/**/live/*_live.ex"] = {
       type = "liveview",
-      alternate = "test/{dirname}/live/{basename}_live.exs",
+      alternate = "test/{dirname}/live/{basename}_live_test.exs",
       template = {
         "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}Live do",
         "  use {dirname|camelcase|capitalize}, :live_view",

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -71,7 +71,7 @@ local config = {
         "end",
       },
     },
-    ["test/**/controllers/*_test.exs"] = {
+    ["test/**/components/*_test.exs"] = {
       type = "test",
       alternate = "lib/{dirname}/components/{basename}.ex",
       template = {

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -40,6 +40,28 @@ local config = {
         "end",
       },
     },
+    ["lib/**/controllers/*_html.ex"] = {
+      type = "html",
+      alternate = "test/{dirname}/controllers/{basename}_html_test.exs",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}HTML do",
+        "  use {dirname|camelcase|capitalize}, :html",
+        "",
+        "  embed_templates {basename|snake_case}_html/*",
+        "end",
+      },
+    },
+    ["test/**/controllers/*_html_test.exs"] = {
+      type = "test",
+      alternate = "lib/{dirname}/controllers/{basename}_html.ex",
+      template = {
+        "defmodule {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}ControllerTest do",
+        "  use {dirname|camelcase|capitalize}.ConnCase, async: true",
+        "",
+        "  alias {dirname|camelcase|capitalize}.{basename|camelcase|capitalize}HTML",
+        "end",
+      },
+    },
     ["lib/**/live/*_live.ex"] = {
       type = "liveview",
       alternate = "test/{dirname}/live/{basename}_live_test.exs",


### PR DESCRIPTION
Hello!

This adds the `live` folder to projectionist, though with Phoenix 1.7 lurking around the corner some other additions are likely useful with the modified directory structure.