### PR TITLE
fix: only start credo if it finds a mix.exs with credo in it

### DIFF
--- a/lua/elixir/credo/init.lua
+++ b/lua/elixir/credo/init.lua
@@ -24,20 +24,22 @@ function M.setup(opts)
         file = nil
       end
 
-      local cmd
-      if type(opts.port) == "number" then
-        cmd = vim.lsp.rpc.connect("127.0.0.1", opts.port)
-      else
-        cmd = { opts.cmd, "--stdio" }
-      end
+      if file then
+        local cmd
+        if type(opts.port) == "number" then
+          cmd = vim.lsp.rpc.connect("127.0.0.1", opts.port)
+        else
+          cmd = { opts.cmd, "--stdio" }
+        end
 
-      vim.lsp.start {
-        name = "Credo",
-        cmd = cmd,
-        settings = {},
-        root_dir = vim.fs.dirname(file),
-        on_attach = opts.on_attach or function() end,
-      }
+        vim.lsp.start {
+          name = "Credo",
+          cmd = cmd,
+          settings = {},
+          root_dir = vim.fs.dirname(file),
+          on_attach = opts.on_attach or function() end,
+        }
+      end
     end,
   })
 end


### PR DESCRIPTION
Fixes #67
