### PR TITLE
feat(treesitter): injections

### DIFF
--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -1,0 +1,15 @@
+; extends
+
+(call
+  target: ((identifier) @_identifier (#eq? @_identifier "execute"))
+  (arguments
+    (string
+      (quoted_content) @sql)))
+
+((call
+   target: (dot
+             left: (alias) @_mod (#eq? @_mod "EEx")
+             right: (identifier) @_func (#eq? @_func "function_from_string"))
+   (arguments
+     (string
+       (quoted_content) @eex))))


### PR DESCRIPTION
- highlight the template argument of `EEx.function_from_string` as `eex`
- highlight the argument of `execute` as `sql` (Ecto migrations).

Closes #9
