### PR TITLE
fix: improve BufEnter performance

### DIFF
--- a/lua/elixir/elixirls/init.lua
+++ b/lua/elixir/elixirls/init.lua
@@ -349,7 +349,7 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd({ "FileType" }, {
     group = elixir_group,
     pattern = { "elixir", "eelixir", "heex", "surface" },
-    callback = start_elixir_ls,
+    callback = vim.schedule_wrap(start_elixir_ls),
   })
 end
 


### PR DESCRIPTION
we are running `elixir --version` every single time we attach to an elixir filetype (on FileType), so
we need to schedule the callback for later as to not slow down BufEnter.

Fixes #59

---

I tested this using @NJichev's dotfiles using `NVIM_APPNAME nj-nvim nvim path/to/file.ex` (with his dotfiles cloned to `~/.config/nj-nvim`).

I tested before the change, after the change, and not including the plug-in at all (completely uninstalled it). 

@NJichev, please try out this branch and confirm it works for you and i'll merge.

<details><summary>--startuptime before.txt</summary>
<p>

```


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.005  000.005: --- NVIM STARTING ---
000.042  000.037: event init
000.100  000.059: early init
000.292  000.192: locale set
000.314  000.022: init first window
000.474  000.160: inits 1
000.484  000.009: window checked
000.551  000.068: parsing arguments
000.801  000.019  000.019: require('vim.shared')
000.849  000.021  000.021: require('vim._meta')
000.850  000.047  000.027: require('vim._editor')
000.851  000.102  000.036: require('vim._init_packages')
000.851  000.198: init lua interpreter
002.183  001.332: expanding arguments
002.204  000.021: inits 2
002.353  000.150: init highlight
002.354  000.001: waiting for UI
002.450  000.097: done waiting for UI
002.461  000.011: clear screen
002.641  000.180: init default mappings & autocommands
003.300  000.271  000.271: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin.vim
003.605  000.259  000.259: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/indent.vim
004.484  000.507  000.507: require('keybinds')
004.664  000.178  000.178: require('lazy')
004.684  000.011  000.011: require('ffi')
004.706  000.021  000.021: require('vim.loader')
004.776  000.021  000.021: require('vim.fs')
004.963  000.237  000.216: require('lazy.stats')
005.188  000.204  000.204: require('lazy.core.util')
005.454  000.265  000.265: require('lazy.core.config')
005.793  000.153  000.153: require('lazy.core.handler')
005.937  000.143  000.143: require('lazy.core.plugin')
005.942  000.486  000.189: require('lazy.core.loader')
006.407  000.281  000.281: require('plugins')
006.645  000.195  000.195: require('plugins.cmp')
006.853  000.193  000.193: require('plugins.elixir')
007.078  000.211  000.211: require('plugins.fzf')
007.322  000.237  000.237: require('plugins.lsp')
007.969  000.631  000.631: require('plugins.noice')
008.239  000.260  000.260: require('plugins.treesitter')
008.932  000.306  000.306: require('lazy.core.handler.cmd')
009.456  000.300  000.300: require('lazy.core.handler.event')
009.458  000.523  000.223: require('lazy.core.handler.ft')
009.679  000.218  000.218: require('lazy.core.handler.keys')
009.821  000.003  000.003: require('vim.keymap')
010.679  000.382  000.382: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
011.621  000.832  000.832: require('gruvbox')
012.191  000.331  000.331: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/editorconfig.lua
012.506  000.260  000.260: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/gzip.vim
012.671  000.123  000.123: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/man.lua
013.487  000.196  000.196: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
013.569  000.858  000.662: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchit.vim
013.818  000.211  000.211: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchparen.vim
014.181  000.304  000.304: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/netrwPlugin.vim
014.438  000.194  000.194: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/nvim.lua
014.639  000.147  000.147: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/rplugin.vim
014.794  000.100  000.100: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/shada.vim
014.899  000.050  000.050: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/spellfile.vim
015.030  000.071  000.071: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tarPlugin.vim
015.163  000.073  000.073: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tohtml.vim
015.259  000.032  000.032: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tutor.vim
015.415  000.085  000.085: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/zipPlugin.vim
015.755  000.083  000.083: sourcing /Users/mitchell/.config/nj-nvim/config/functions.vim
015.999  000.198  000.198: sourcing /Users/mitchell/.config/nj-nvim/config/keybinds.vim
017.374  000.210  000.210: require('vim.version')
018.477  000.397  000.397: require('gruvbox.groups')
018.992  000.513  000.513: require('gruvbox.palette')
019.761  002.775  001.655: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/gruvbox.nvim/colors/gruvbox.lua
019.785  003.741  000.967: sourcing /Users/mitchell/.config/nj-nvim/config/interface.vim
019.956  000.105  000.105: sourcing /Users/mitchell/.config/nj-nvim/config/settings.vim
020.256  000.232  000.232: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/macros/matchit.vim
020.285  016.575  003.193: sourcing /Users/mitchell/.config/nj-nvim/init.lua
020.292  000.547: sourcing vimrc file(s)
020.595  000.235  000.235: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
021.148  000.117  000.117: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/synload.vim
021.196  000.531  000.414: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/syntax.vim
021.202  000.145: inits 3
021.617  000.415: reading ShaDa
022.984  000.217  000.217: require('vim.lsp.log')
023.627  000.642  000.642: require('vim.lsp.protocol')
023.968  000.194  000.194: require('vim.lsp._snippet')
024.230  000.261  000.261: require('vim.highlight')
024.235  000.004  000.004: require('vim.F')
024.243  000.615  000.157: require('vim.lsp.util')
024.248  001.700  000.226: require('vim.lsp.handlers')
024.464  000.215  000.215: require('vim.lsp.rpc')
024.657  000.192  000.192: require('vim.lsp.sync')
024.899  000.241  000.241: require('vim.lsp.semantic_tokens')
025.163  000.263  000.263: require('vim.lsp.buf')
025.364  000.200  000.200: require('vim.lsp.diagnostic')
025.542  000.177  000.177: require('vim.lsp.codelens')
025.584  003.360  000.374: require('vim.lsp')
026.110  004.040  000.679: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-lspconfig/plugin/lspconfig.lua
027.284  000.295  000.295: require('lspconfig.util')
027.285  000.511  000.216: require('lspconfig.configs')
027.287  001.154  000.643: require('lspconfig')
028.714  000.480  000.480: require('cmp_nvim_lsp.source')
028.716  001.000  000.520: require('cmp_nvim_lsp')
028.723  001.148  000.148: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/cmp-nvim-lsp/after/plugin/cmp_nvim_lsp.lua
028.728  001.440  000.292: require('cmp_nvim_lsp')
029.224  000.163  000.163: require('mason-core.path')
029.749  000.320  000.320: require('mason-core.functional')
029.923  000.070  000.070: require('mason-core.functional.data')
029.926  000.167  000.098: require('mason-core.functional.function')
030.003  000.070  000.070: require('mason-core.functional.relation')
030.094  000.088  000.088: require('mason-core.functional.logic')
030.100  000.876  000.230: require('mason-core.platform')
030.174  000.073  000.073: require('mason.settings')
030.175  001.260  000.148: require('mason')
030.862  000.342  000.342: require('mason-core.functional.list')
030.961  000.097  000.097: require('mason-core.functional.string')
030.974  000.616  000.178: require('mason.api.command')
031.053  000.077  000.077: require('mason-registry.sources')
031.208  000.080  000.080: require('mason-core.log')
031.275  000.066  000.066: require('mason-lspconfig.settings')
031.276  000.219  000.074: require('mason-lspconfig')
031.487  000.068  000.068: require('mason-lspconfig.notify')
031.489  000.141  000.072: require('mason-lspconfig.lspconfig_hook')
031.639  000.070  000.070: require('mason-core.functional.table')
031.662  000.172  000.102: require('mason-lspconfig.mappings.server')
031.803  000.064  000.064: require('mason-core.EventEmitter')
031.941  000.138  000.138: require('mason-core.optional')
032.197  000.075  000.075: require('mason-core.async')
032.494  000.295  000.295: require('mason-core.async.uv')
032.497  000.539  000.169: require('mason-core.fs')
032.506  000.843  000.101: require('mason-registry')
032.577  000.070  000.070: require('mason-lspconfig.server_config_extensions')
032.672  000.094  000.094: require('lspconfig.server_configurations.omnisharp')
032.794  000.068  000.068: require('mason-lspconfig.ensure_installed')
033.171  000.073  000.073: require('mason-core.result')
033.202  000.174  000.101: require('mason-core.purl')
033.208  000.336  000.161: require('mason-core.package')
033.542  000.173  000.173: require('mason-core.process')
033.625  000.082  000.082: require('mason-core.spawn')
033.627  000.329  000.074: require('mason-core.managers.powershell')
033.628  000.420  000.091: require('mason-core.fetch')
033.698  000.069  000.069: require('mason-core.providers')
034.086  000.083  000.083: require('mason-core.installer.registry.expr')
034.094  000.231  000.148: require('mason-core.installer.registry.link')
034.705  000.113  000.113: require('mason-core.receipt')
034.717  000.334  000.221: require('mason-core.installer.context')
034.797  000.079  000.079: require('mason-core.async.control')
034.887  000.089  000.089: require('mason-core.installer.linker')
034.890  000.605  000.103: require('mason-core.installer')
034.904  000.711  000.106: require('mason-core.installer.managers.std')
034.905  000.810  000.099: require('mason-core.installer.registry.schemas')
034.911  001.212  000.170: require('mason-core.installer.registry')
034.917  002.120  000.084: require('mason-registry.sources.github')
038.595  000.080  000.080: require('mason-core.functional.number')
038.607  000.185  000.105: require('mason-lspconfig.api.command')
038.689  000.080  000.080: require('lspconfig.server_configurations.lua_ls')
041.007  000.186  000.186: require('lspconfig.server_configurations.tailwindcss')
041.882  000.184  000.184: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/plenary.nvim/plugin/plenary.vim
042.774  000.094  000.094: require('plenary.bit')
042.925  000.150  000.150: require('plenary.functional')
042.937  000.450  000.206: require('plenary.path')
043.298  000.171  000.171: require('plenary.strings')
043.300  000.262  000.091: require('plenary.window.border')
043.778  000.477  000.477: require('plenary.window')
043.880  000.101  000.101: require('plenary.popup.utils')
043.882  000.945  000.105: require('plenary.popup')
043.984  000.101  000.101: require('elixir.elixirls.version')
044.230  000.168  000.168: require('plenary.job')
044.298  000.068  000.068: require('elixir.utils')
044.299  000.314  000.079: require('elixir.elixirls.download')
044.403  000.036  000.036: require('vim.inspect')
044.520  000.220  000.185: require('elixir.elixirls.compile')
044.570  002.176  000.146: require('elixir.elixirls')
044.667  000.096  000.096: require('elixir.credo')
044.921  000.062  000.062: require('elixir.mix.git')
044.922  000.125  000.062: require('elixir.mix.exs')
044.923  000.189  000.064: require('elixir.mix.wrapper')
044.925  000.256  000.068: require('elixir.mix')
045.072  000.147  000.147: require('elixir.projectionist')
045.077  003.167  000.491: require('elixir')
046.489  000.106  000.106: require('vim.treesitter.language')
046.493  000.274  000.167: require('vim.treesitter.query')
046.614  000.121  000.121: require('vim.treesitter._range')
046.618  000.577  000.183: require('vim.treesitter.languagetree')
046.620  000.836  000.258: require('vim.treesitter')
046.893  000.271  000.271: require('vim.treesitter.highlighter')
047.025  000.131  000.131: require('treesitter-context.cache')
048.493  000.159  000.159: require('nvim-treesitter.compat')
049.306  000.576  000.576: require('nvim-treesitter.parsers')
049.394  000.087  000.087: require('nvim-treesitter.utils')
049.399  000.832  000.168: require('nvim-treesitter.ts_utils')
049.401  000.907  000.076: require('nvim-treesitter.tsrange')
049.475  000.073  000.073: require('nvim-treesitter.caching')
049.480  001.331  000.191: require('nvim-treesitter.query')
049.502  001.533  000.203: require('nvim-treesitter.configs')
049.503  001.986  000.452: require('nvim-treesitter-textobjects')
049.944  000.179  000.179: require('nvim-treesitter.info')
050.161  000.217  000.217: require('nvim-treesitter.shell_command_selectors')
050.182  000.592  000.197: require('nvim-treesitter.install')
050.282  000.098  000.098: require('nvim-treesitter.statusline')
050.534  000.251  000.251: require('nvim-treesitter.query_predicates')
050.535  001.031  000.089: require('nvim-treesitter')
051.021  000.179  000.179: require('nvim-treesitter.textobjects.shared')
051.025  000.483  000.304: require('nvim-treesitter.textobjects.select')
051.541  000.167  000.167: require('nvim-treesitter.textobjects.attach')
051.638  000.095  000.095: require('nvim-treesitter.textobjects.repeatable_move')
051.642  000.598  000.336: require('nvim-treesitter.textobjects.move')
051.864  000.149  000.149: require('nvim-treesitter.textobjects.swap')
052.696  000.821  000.821: require('nvim-treesitter.textobjects.lsp_interop')
052.708  005.330  000.262: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textobjects/plugin/nvim-treesitter-textobjects.vim
053.340  000.369  000.369: require('nvim-treesitter-textsubjects')
053.342  000.474  000.104: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textsubjects/plugin/nvim-treesitter-textsubjects.vim
053.951  000.075  000.075: require('nvim-tree-docs.aniseed.autoload')
053.954  000.405  000.331: require('nvim-tree-docs.main')
053.958  000.513  000.108: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-tree-docs/plugin/nvim-tree-docs.vim
054.481  000.309  000.309: require('ts_context_commentstring')
054.483  000.411  000.102: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-context-commentstring/plugin/ts_context_commentstring.vim
054.932  000.309  000.309: require('nvim-treesitter-endwise')
054.934  000.358  000.049: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-endwise/plugin/nvim-treesitter-endwise.lua
055.771  000.071  000.071: require('nvim-ts-autotag._log')
055.773  000.154  000.083: require('nvim-ts-autotag.utils')
055.781  000.337  000.183: require('nvim-ts-autotag.internal')
055.782  000.651  000.314: require('nvim-ts-autotag')
055.785  000.749  000.098: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-autotag/plugin/nvim-ts-autotag.vim
056.313  000.333  000.333: require('rainbow')
056.319  000.430  000.097: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-rainbow/plugin/rainbow.vim
057.235  000.673  000.673: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter/plugin/nvim-treesitter.lua
062.688  000.078  000.078: require('ts_context_commentstring.utils')
062.692  000.219  000.141: require('ts_context_commentstring.internal')
063.108  000.131  000.131: require('nvim-treesitter.endwise')
063.541  000.266  000.266: require('nvim-treesitter.indent')
063.709  000.132  000.132: require('rainbow.internal')
063.873  000.131  000.131: require('nvim-treesitter.highlight')
064.314  000.166  000.166: require('nvim-treesitter.locals')
064.316  000.430  000.264: require('nvim-treesitter.incremental_selection')
064.324  017.299  007.052: require('nvim-treesitter.parsers')
064.343  018.950  000.414: require('treesitter-context')
064.344  019.057  000.106: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-context/plugin/treesitter-context.vim
065.189  000.181  000.181: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-tmux-navigator/plugin/tmux_navigator.vim
065.903  000.402  000.402: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-surround/plugin/surround.vim
066.492  000.252  000.252: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/auto-pairs/plugin/auto-pairs.vim
067.786  000.325  000.325: require('Comment.config')
068.125  000.181  000.181: require('Comment.ft')
068.127  000.340  000.159: require('Comment.utils')
068.199  000.071  000.071: require('Comment.opfunc')
068.269  000.069  000.069: require('Comment.extra')
068.287  001.323  000.519: require('Comment.api')
068.354  001.567  000.243: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/Comment.nvim/plugin/Comment.lua
068.434  000.069  000.069: require('Comment')
068.807  000.236  000.236: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-endwise/plugin/endwise.vim
069.429  000.324  000.324: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/CamelCaseMotion/plugin/camelcasemotion.vim
070.207  000.471  000.471: require('vim.filetype')
070.893  000.310  000.310: require('vim.filetype.detect')
071.683  000.192  000.192: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin/elixir.vim
073.885  000.210  000.210: require('vim.uri')
680.321  000.315  000.315: require('rainbow.levels')
754.686  000.946  000.946: require('editorconfig')
755.967  000.374  000.374: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/autoload/provider/clipboard.vim
756.272  693.636: opening buffers
778.899  022.627: BufEnter autocommands
778.902  000.003: editing files in windows
779.041  000.139: VimEnter autocommands
779.068  000.027: UIEnter autocommands
779.070  000.002: before starting main loop
901.259  122.189: first screen update
901.262  000.003: --- NVIM STARTED ---


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.006  000.006: --- NVIM STARTING ---
000.102  000.097: event init
000.227  000.124: early init
000.430  000.204: locale set
000.507  000.077: init first window
000.764  000.258: inits 1
000.769  000.004: window checked
000.846  000.077: parsing arguments
001.209  000.020  000.020: require('vim.shared')
001.256  000.020  000.020: require('vim._meta')
001.257  000.047  000.027: require('vim._editor')
001.258  000.110  000.044: require('vim._init_packages')
001.259  000.303: init lua interpreter
001.431  000.172: expanding arguments
001.439  000.009: inits 2
001.652  000.213: init highlight

```

</p>
</details> 

<details><summary>--startuptime after.txt</summary>
<p>

```


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.004  000.004: --- NVIM STARTING ---
000.041  000.037: event init
000.100  000.059: early init
000.297  000.197: locale set
000.318  000.021: init first window
000.481  000.163: inits 1
000.491  000.010: window checked
000.562  000.071: parsing arguments
000.817  000.019  000.019: require('vim.shared')
000.864  000.021  000.021: require('vim._meta')
000.865  000.047  000.026: require('vim._editor')
000.866  000.105  000.039: require('vim._init_packages')
000.866  000.200: init lua interpreter
002.130  001.263: expanding arguments
002.150  000.020: inits 2
002.304  000.155: init highlight
002.305  000.001: waiting for UI
002.441  000.136: done waiting for UI
002.452  000.011: clear screen
002.638  000.186: init default mappings & autocommands
003.073  000.171  000.171: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin.vim
003.270  000.142  000.142: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/indent.vim
004.005  000.477  000.477: require('keybinds')
004.193  000.186  000.186: require('lazy')
004.214  000.011  000.011: require('ffi')
004.237  000.021  000.021: require('vim.loader')
004.306  000.020  000.020: require('vim.fs')
004.490  000.234  000.214: require('lazy.stats')
004.708  000.199  000.199: require('lazy.core.util')
004.958  000.248  000.248: require('lazy.core.config')
005.274  000.144  000.144: require('lazy.core.handler')
005.435  000.160  000.160: require('lazy.core.plugin')
005.439  000.480  000.176: require('lazy.core.loader')
005.842  000.253  000.253: require('plugins')
006.053  000.167  000.167: require('plugins.cmp')
006.636  000.350  000.350: require('plugins.elixir')
006.873  000.206  000.206: require('plugins.fzf')
007.085  000.204  000.204: require('plugins.lsp')
007.339  000.134  000.134: require('plugins.noice')
007.683  000.213  000.213: require('plugins.treesitter')
008.266  000.220  000.220: require('lazy.core.handler.keys')
008.475  000.204  000.204: require('lazy.core.handler.cmd')
008.768  000.291  000.291: require('lazy.core.handler.event')
008.908  000.138  000.138: require('lazy.core.handler.ft')
008.989  000.003  000.003: require('vim.keymap')
009.835  000.298  000.298: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
010.224  000.300  000.300: require('gruvbox')
010.559  000.158  000.158: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/editorconfig.lua
010.794  000.187  000.187: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/gzip.vim
010.969  000.128  000.128: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/man.lua
011.903  000.262  000.262: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
012.012  001.002  000.740: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchit.vim
012.183  000.122  000.122: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchparen.vim
012.422  000.191  000.191: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/netrwPlugin.vim
012.623  000.152  000.152: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/nvim.lua
012.776  000.111  000.111: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/rplugin.vim
012.869  000.052  000.052: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/shada.vim
012.953  000.043  000.043: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/spellfile.vim
013.068  000.063  000.063: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tarPlugin.vim
013.191  000.067  000.067: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tohtml.vim
013.260  000.028  000.028: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tutor.vim
013.401  000.081  000.081: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/zipPlugin.vim
013.683  000.038  000.038: sourcing /Users/mitchell/.config/nj-nvim/config/functions.vim
013.879  000.153  000.153: sourcing /Users/mitchell/.config/nj-nvim/config/keybinds.vim
015.291  000.585  000.585: require('vim.version')
016.218  000.373  000.373: require('gruvbox.groups')
016.422  000.202  000.202: require('gruvbox.palette')
017.190  002.563  001.404: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/gruvbox.nvim/colors/gruvbox.lua
017.200  003.278  000.715: sourcing /Users/mitchell/.config/nj-nvim/config/interface.vim
017.354  000.103  000.103: sourcing /Users/mitchell/.config/nj-nvim/config/settings.vim
017.548  000.128  000.128: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/macros/matchit.vim
017.575  014.223  003.300: sourcing /Users/mitchell/.config/nj-nvim/init.lua
017.579  000.406: sourcing vimrc file(s)
017.671  000.034  000.034: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
017.970  000.096  000.096: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/synload.vim
018.012  000.276  000.181: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/syntax.vim
018.018  000.128: inits 3
018.363  000.345: reading ShaDa
019.777  000.144  000.144: require('vim.treesitter.language')
019.782  000.330  000.186: require('vim.treesitter.query')
019.920  000.138  000.138: require('vim.treesitter._range')
019.924  000.681  000.213: require('vim.treesitter.languagetree')
019.927  000.877  000.196: require('vim.treesitter')
020.173  000.245  000.245: require('vim.treesitter.highlighter')
020.356  000.182  000.182: require('treesitter-context.cache')
021.902  000.155  000.155: require('nvim-treesitter.compat')
022.838  000.624  000.624: require('nvim-treesitter.parsers')
022.930  000.091  000.091: require('nvim-treesitter.utils')
022.933  000.895  000.180: require('nvim-treesitter.ts_utils')
022.937  001.033  000.138: require('nvim-treesitter.tsrange')
023.038  000.101  000.101: require('nvim-treesitter.caching')
023.051  001.498  000.208: require('nvim-treesitter.query')
023.062  001.758  000.261: require('nvim-treesitter.configs')
023.064  002.189  000.431: require('nvim-treesitter-textobjects')
023.659  000.324  000.324: require('nvim-treesitter.info')
023.920  000.260  000.260: require('nvim-treesitter.shell_command_selectors')
023.938  000.783  000.199: require('nvim-treesitter.install')
024.008  000.069  000.069: require('nvim-treesitter.statusline')
024.252  000.244  000.244: require('nvim-treesitter.query_predicates')
024.254  001.189  000.094: require('nvim-treesitter')
024.715  000.164  000.164: require('nvim-treesitter.textobjects.shared')
024.717  000.460  000.296: require('nvim-treesitter.textobjects.select')
025.242  000.162  000.162: require('nvim-treesitter.textobjects.attach')
025.331  000.089  000.089: require('nvim-treesitter.textobjects.repeatable_move')
025.342  000.615  000.364: require('nvim-treesitter.textobjects.move')
025.538  000.134  000.134: require('nvim-treesitter.textobjects.swap')
026.353  000.804  000.804: require('nvim-treesitter.textobjects.lsp_interop')
026.373  005.615  000.224: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textobjects/plugin/nvim-treesitter-textobjects.vim
026.878  000.298  000.298: require('nvim-treesitter-textsubjects')
026.880  000.390  000.092: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textsubjects/plugin/nvim-treesitter-textsubjects.vim
027.527  000.072  000.072: require('nvim-tree-docs.aniseed.autoload')
027.529  000.446  000.374: require('nvim-tree-docs.main')
027.533  000.547  000.101: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-tree-docs/plugin/nvim-tree-docs.vim
028.084  000.330  000.330: require('ts_context_commentstring')
028.086  000.437  000.106: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-context-commentstring/plugin/ts_context_commentstring.vim
028.591  000.331  000.331: require('nvim-treesitter-endwise')
028.593  000.401  000.070: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-endwise/plugin/nvim-treesitter-endwise.lua
029.443  000.091  000.091: require('nvim-ts-autotag._log')
029.444  000.171  000.080: require('nvim-ts-autotag.utils')
029.449  000.353  000.182: require('nvim-ts-autotag.internal')
029.450  000.659  000.306: require('nvim-ts-autotag')
029.451  000.754  000.095: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-autotag/plugin/nvim-ts-autotag.vim
029.898  000.266  000.266: require('rainbow')
029.904  000.368  000.102: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-rainbow/plugin/rainbow.vim
030.630  000.535  000.535: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter/plugin/nvim-treesitter.lua
034.766  000.115  000.115: require('nvim-treesitter.endwise')
035.163  000.141  000.141: require('rainbow.internal')
035.432  000.246  000.246: require('nvim-treesitter.indent')
035.795  000.176  000.176: require('nvim-treesitter.locals')
035.797  000.354  000.178: require('nvim-treesitter.incremental_selection')
036.051  000.102  000.102: require('ts_context_commentstring.utils')
036.059  000.215  000.112: require('ts_context_commentstring.internal')
036.227  000.126  000.126: require('nvim-treesitter.highlight')
036.230  015.873  005.628: require('nvim-treesitter.parsers')
036.248  017.604  000.428: require('treesitter-context')
036.250  017.708  000.104: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-context/plugin/treesitter-context.vim
037.663  000.207  000.207: require('vim.lsp.log')
038.131  000.467  000.467: require('vim.lsp.protocol')
038.823  000.538  000.538: require('vim.lsp._snippet')
039.020  000.196  000.196: require('vim.highlight')
039.037  000.012  000.012: require('vim.F')
039.046  000.913  000.168: require('vim.lsp.util')
039.060  001.829  000.242: require('vim.lsp.handlers')
039.251  000.189  000.189: require('vim.lsp.rpc')
039.427  000.175  000.175: require('vim.lsp.sync')
039.602  000.174  000.174: require('vim.lsp.semantic_tokens')
039.781  000.177  000.177: require('vim.lsp.buf')
039.922  000.140  000.140: require('vim.lsp.diagnostic')
040.039  000.116  000.116: require('vim.lsp.codelens')
040.089  003.157  000.356: require('vim.lsp')
040.514  003.748  000.591: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-lspconfig/plugin/lspconfig.lua
041.375  000.231  000.231: require('lspconfig.util')
041.376  000.390  000.159: require('lspconfig.configs')
041.378  000.852  000.461: require('lspconfig')
042.652  000.483  000.483: require('cmp_nvim_lsp.source')
042.654  000.895  000.412: require('cmp_nvim_lsp')
042.661  001.051  000.156: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/cmp-nvim-lsp/after/plugin/cmp_nvim_lsp.lua
042.666  001.287  000.236: require('cmp_nvim_lsp')
043.015  000.160  000.160: require('mason-core.path')
043.484  000.273  000.273: require('mason-core.functional')
043.616  000.060  000.060: require('mason-core.functional.data')
043.619  000.125  000.066: require('mason-core.functional.function')
043.684  000.060  000.060: require('mason-core.functional.relation')
043.746  000.059  000.059: require('mason-core.functional.logic')
043.759  000.744  000.227: require('mason-core.platform')
043.824  000.064  000.064: require('mason.settings')
043.826  001.101  000.133: require('mason')
044.395  000.307  000.307: require('mason-core.functional.list')
044.472  000.075  000.075: require('mason-core.functional.string')
044.485  000.572  000.191: require('mason.api.command')
044.570  000.082  000.082: require('mason-registry.sources')
044.747  000.086  000.086: require('mason-core.log')
044.814  000.066  000.066: require('mason-lspconfig.settings')
044.816  000.232  000.080: require('mason-lspconfig')
044.944  000.059  000.059: require('mason-lspconfig.notify')
044.946  000.125  000.066: require('mason-lspconfig.lspconfig_hook')
045.103  000.067  000.067: require('mason-core.functional.table')
045.126  000.163  000.097: require('mason-lspconfig.mappings.server')
045.274  000.066  000.066: require('mason-core.EventEmitter')
045.431  000.156  000.156: require('mason-core.optional')
045.684  000.075  000.075: require('mason-core.async')
045.925  000.240  000.240: require('mason-core.async.uv')
045.928  000.495  000.181: require('mason-core.fs')
045.936  000.809  000.092: require('mason-registry')
045.997  000.060  000.060: require('mason-lspconfig.server_config_extensions')
046.064  000.066  000.066: require('lspconfig.server_configurations.omnisharp')
046.170  000.061  000.061: require('mason-lspconfig.ensure_installed')
046.546  000.064  000.064: require('mason-core.result')
046.577  000.161  000.097: require('mason-core.purl')
046.583  000.336  000.175: require('mason-core.package')
046.951  000.241  000.241: require('mason-core.process')
047.023  000.071  000.071: require('mason-core.spawn')
047.024  000.375  000.063: require('mason-core.managers.powershell')
047.025  000.442  000.067: require('mason-core.fetch')
047.093  000.067  000.067: require('mason-core.providers')
047.490  000.099  000.099: require('mason-core.installer.registry.expr')
047.497  000.264  000.165: require('mason-core.installer.registry.link')
048.022  000.093  000.093: require('mason-core.receipt')
048.049  000.292  000.199: require('mason-core.installer.context')
048.126  000.076  000.076: require('mason-core.async.control')
048.220  000.093  000.093: require('mason-core.installer.linker')
048.223  000.561  000.100: require('mason-core.installer')
048.236  000.670  000.109: require('mason-core.installer.managers.std')
048.237  000.740  000.070: require('mason-core.installer.registry.schemas')
048.242  001.148  000.144: require('mason-core.installer.registry')
048.250  002.072  000.079: require('mason-registry.sources.github')
051.895  000.074  000.074: require('mason-core.functional.number')
051.906  000.171  000.097: require('mason-lspconfig.api.command')
051.993  000.085  000.085: require('lspconfig.server_configurations.lua_ls')
052.917  000.104  000.104: require('lspconfig.server_configurations.tailwindcss')
053.713  000.127  000.127: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/plenary.nvim/plugin/plenary.vim
054.955  000.104  000.104: require('plenary.bit')
055.108  000.152  000.152: require('plenary.functional')
055.120  000.481  000.225: require('plenary.path')
055.683  000.191  000.191: require('plenary.strings')
055.689  000.352  000.161: require('plenary.window.border')
055.924  000.235  000.235: require('plenary.window')
056.396  000.470  000.470: require('plenary.popup.utils')
056.402  001.281  000.223: require('plenary.popup')
056.541  000.138  000.138: require('elixir.elixirls.version')
056.965  000.295  000.295: require('plenary.job')
057.057  000.092  000.092: require('elixir.utils')
057.058  000.517  000.130: require('elixir.elixirls.download')
057.158  000.036  000.036: require('vim.inspect')
057.233  000.174  000.138: require('elixir.elixirls.compile')
057.304  003.048  000.457: require('elixir.elixirls')
057.422  000.117  000.117: require('elixir.credo')
057.693  000.059  000.059: require('elixir.mix.git')
057.694  000.124  000.065: require('elixir.mix.exs')
057.695  000.191  000.067: require('elixir.mix.wrapper')
057.697  000.273  000.082: require('elixir.mix')
057.840  000.143  000.143: require('elixir.projectionist')
057.846  004.086  000.506: require('elixir')
058.873  000.178  000.178: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-tmux-navigator/plugin/tmux_navigator.vim
059.457  000.281  000.281: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/CamelCaseMotion/plugin/camelcasemotion.vim
060.839  000.270  000.270: require('Comment.config')
061.163  000.170  000.170: require('Comment.ft')
061.166  000.325  000.155: require('Comment.utils')
061.231  000.064  000.064: require('Comment.opfunc')
061.293  000.061  000.061: require('Comment.extra')
061.295  001.218  000.497: require('Comment.api')
061.371  001.437  000.219: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/Comment.nvim/plugin/Comment.lua
061.470  000.073  000.073: require('Comment')
061.872  000.249  000.249: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-endwise/plugin/endwise.vim
062.577  000.410  000.410: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-surround/plugin/surround.vim
063.090  000.226  000.226: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/auto-pairs/plugin/auto-pairs.vim
063.611  000.450  000.450: require('vim.filetype')
064.294  000.286  000.286: require('vim.filetype.detect')
065.271  000.219  000.219: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin/elixir.vim
238.125  000.261  000.261: require('rainbow.levels')
307.641  000.875  000.875: require('vim.uri')
310.151  000.417  000.417: require('editorconfig')
311.015  000.268  000.268: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/autoload/provider/clipboard.vim
311.256  253.750: opening buffers
334.918  023.662: BufEnter autocommands
334.923  000.005: editing files in windows
335.062  000.139: VimEnter autocommands
335.089  000.027: UIEnter autocommands
335.091  000.003: before starting main loop
452.434  117.343: first screen update
452.437  000.003: --- NVIM STARTED ---


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.005  000.005: --- NVIM STARTING ---
000.080  000.075: event init
000.185  000.105: early init
000.518  000.332: locale set
000.574  000.057: init first window
000.790  000.216: inits 1
000.795  000.004: window checked
000.877  000.082: parsing arguments
001.229  000.020  000.020: require('vim.shared')
001.277  000.020  000.020: require('vim._meta')
001.278  000.047  000.027: require('vim._editor')
001.278  000.110  000.043: require('vim._init_packages')
001.279  000.292: init lua interpreter
001.444  000.165: expanding arguments
001.454  000.010: inits 2
001.658  000.204: init highlight
```

</p>
</details> 

<details><summary>--startuptime noplugin.txt</summary>
<p>

```


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.004  000.004: --- NVIM STARTING ---
000.042  000.038: event init
000.099  000.057: early init
000.327  000.228: locale set
000.349  000.022: init first window
000.510  000.161: inits 1
000.520  000.010: window checked
000.589  000.069: parsing arguments
000.842  000.031  000.031: require('vim.shared')
000.889  000.020  000.020: require('vim._meta')
000.890  000.046  000.026: require('vim._editor')
000.891  000.112  000.034: require('vim._init_packages')
000.891  000.190: init lua interpreter
002.230  001.339: expanding arguments
002.251  000.021: inits 2
002.403  000.152: init highlight
002.404  000.001: waiting for UI
002.504  000.100: done waiting for UI
002.515  000.011: clear screen
002.624  000.110: init default mappings & autocommands
004.248  000.202  000.202: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin.vim
004.444  000.142  000.142: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/indent.vim
005.202  000.478  000.478: require('keybinds')
005.379  000.177  000.177: require('lazy')
005.399  000.011  000.011: require('ffi')
005.419  000.018  000.018: require('vim.loader')
005.483  000.020  000.020: require('vim.fs')
005.819  000.382  000.362: require('lazy.stats')
006.035  000.196  000.196: require('lazy.core.util')
006.275  000.239  000.239: require('lazy.core.config')
006.602  000.141  000.141: require('lazy.core.handler')
006.728  000.124  000.124: require('lazy.core.plugin')
006.731  000.455  000.189: require('lazy.core.loader')
007.096  000.215  000.215: require('plugins')
007.301  000.162  000.162: require('plugins.cmp')
007.459  000.134  000.134: require('plugins.elixir')
007.645  000.184  000.184: require('plugins.fzf')
007.812  000.159  000.159: require('plugins.lsp')
007.949  000.117  000.117: require('plugins.noice')
008.134  000.179  000.179: require('plugins.treesitter')
008.719  000.351  000.351: require('lazy.core.handler.event')
008.884  000.162  000.162: require('lazy.core.handler.ft')
009.252  000.366  000.366: require('lazy.core.handler.keys')
009.406  000.152  000.152: require('lazy.core.handler.cmd')
009.557  000.010  000.010: require('vim.keymap')
010.743  000.536  000.536: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
011.165  000.352  000.352: require('gruvbox')
011.533  000.200  000.200: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/editorconfig.lua
011.775  000.188  000.188: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/gzip.vim
011.936  000.119  000.119: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/man.lua
012.617  000.230  000.230: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
012.696  000.724  000.494: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchit.vim
012.908  000.175  000.175: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/matchparen.vim
013.119  000.175  000.175: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/netrwPlugin.vim
013.395  000.235  000.235: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/nvim.lua
013.559  000.122  000.122: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/rplugin.vim
013.704  000.101  000.101: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/shada.vim
013.792  000.046  000.046: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/spellfile.vim
013.910  000.066  000.066: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tarPlugin.vim
014.025  000.074  000.074: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tohtml.vim
014.108  000.029  000.029: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/tutor.vim
014.256  000.080  000.080: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/plugin/zipPlugin.vim
014.689  000.036  000.036: sourcing /Users/mitchell/.config/nj-nvim/config/functions.vim
014.886  000.154  000.154: sourcing /Users/mitchell/.config/nj-nvim/config/keybinds.vim
016.139  000.252  000.252: require('vim.version')
017.058  000.333  000.333: require('gruvbox.groups')
017.238  000.178  000.178: require('gruvbox.palette')
017.930  002.101  001.338: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/gruvbox.nvim/colors/gruvbox.lua
017.938  003.008  000.907: sourcing /Users/mitchell/.config/nj-nvim/config/interface.vim
018.059  000.071  000.071: sourcing /Users/mitchell/.config/nj-nvim/config/settings.vim
018.246  000.116  000.116: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/macros/matchit.vim
018.274  013.727  002.973: sourcing /Users/mitchell/.config/nj-nvim/init.lua
018.280  001.584: sourcing vimrc file(s)
018.385  000.037  000.037: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/filetype.lua
018.714  000.094  000.094: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/synload.vim
018.756  000.295  000.201: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/syntax/syntax.vim
018.762  000.150: inits 3
019.100  000.338: reading ShaDa
020.849  000.149  000.149: require('vim.lsp.log')
021.350  000.500  000.500: require('vim.lsp.protocol')
021.703  000.211  000.211: require('vim.lsp._snippet')
021.873  000.169  000.169: require('vim.highlight')
021.878  000.004  000.004: require('vim.F')
021.885  000.534  000.150: require('vim.lsp.util')
021.892  001.400  000.217: require('vim.lsp.handlers')
022.102  000.210  000.210: require('vim.lsp.rpc')
022.335  000.232  000.232: require('vim.lsp.sync')
022.639  000.303  000.303: require('vim.lsp.semantic_tokens')
022.870  000.229  000.229: require('vim.lsp.buf')
023.054  000.183  000.183: require('vim.lsp.diagnostic')
023.230  000.175  000.175: require('vim.lsp.codelens')
023.270  003.124  000.394: require('vim.lsp')
023.809  003.962  000.838: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-lspconfig/plugin/lspconfig.lua
025.733  000.212  000.212: require('lspconfig.util')
025.735  000.415  000.202: require('lspconfig.configs')
025.736  001.902  001.487: require('lspconfig')
027.178  000.514  000.514: require('cmp_nvim_lsp.source')
027.180  000.917  000.404: require('cmp_nvim_lsp')
027.187  001.112  000.194: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/cmp-nvim-lsp/after/plugin/cmp_nvim_lsp.lua
027.192  001.456  000.344: require('cmp_nvim_lsp')
027.783  000.157  000.157: require('mason-core.path')
028.259  000.271  000.271: require('mason-core.functional')
028.399  000.063  000.063: require('mason-core.functional.data')
028.402  000.134  000.071: require('mason-core.functional.function')
028.474  000.066  000.066: require('mason-core.functional.relation')
028.542  000.065  000.065: require('mason-core.functional.logic')
028.547  000.763  000.227: require('mason-core.platform')
028.617  000.069  000.069: require('mason.settings')
028.618  001.229  000.240: require('mason')
029.205  000.312  000.312: require('mason-core.functional.list')
029.274  000.067  000.067: require('mason-core.functional.string')
029.285  000.570  000.190: require('mason.api.command')
029.567  000.279  000.279: require('mason-registry.sources')
029.736  000.074  000.074: require('mason-core.log')
029.813  000.076  000.076: require('mason-lspconfig.settings')
029.817  000.246  000.096: require('mason-lspconfig')
030.080  000.187  000.187: require('mason-lspconfig.notify')
030.083  000.262  000.075: require('mason-lspconfig.lspconfig_hook')
030.245  000.083  000.083: require('mason-core.functional.table')
030.269  000.185  000.102: require('mason-lspconfig.mappings.server')
030.566  000.227  000.227: require('mason-core.EventEmitter')
030.770  000.203  000.203: require('mason-core.optional')
031.011  000.079  000.079: require('mason-core.async')
031.282  000.270  000.270: require('mason-core.async.uv')
031.286  000.499  000.150: require('mason-core.fs')
031.295  001.025  000.097: require('mason-registry')
031.358  000.062  000.062: require('mason-lspconfig.server_config_extensions')
031.424  000.065  000.065: require('lspconfig.server_configurations.omnisharp')
031.552  000.067  000.067: require('mason-lspconfig.ensure_installed')
031.956  000.069  000.069: require('mason-core.result')
031.990  000.199  000.131: require('mason-core.purl')
031.996  000.359  000.159: require('mason-core.package')
032.434  000.164  000.164: require('mason-core.process')
032.528  000.093  000.093: require('mason-core.spawn')
032.530  000.463  000.205: require('mason-core.managers.powershell')
032.531  000.534  000.072: require('mason-core.fetch')
032.693  000.160  000.160: require('mason-core.providers')
033.921  000.083  000.083: require('mason-core.installer.registry.expr')
033.929  000.242  000.159: require('mason-core.installer.registry.link')
034.614  000.095  000.095: require('mason-core.receipt')
034.625  000.280  000.185: require('mason-core.installer.context')
034.716  000.090  000.090: require('mason-core.async.control')
034.813  000.095  000.095: require('mason-core.installer.linker')
034.818  000.645  000.179: require('mason-core.installer')
034.837  000.820  000.175: require('mason-core.installer.managers.std')
034.839  000.909  000.089: require('mason-core.installer.registry.schemas')
034.844  002.150  000.999: require('mason-core.installer.registry')
034.850  003.295  000.091: require('mason-registry.sources.github')
038.606  000.078  000.078: require('mason-core.functional.number')
038.616  000.173  000.095: require('mason-lspconfig.api.command')
038.698  000.079  000.079: require('lspconfig.server_configurations.lua_ls')
042.100  000.221  000.221: require('lspconfig.server_configurations.tailwindcss')
044.127  000.106  000.106: require('vim.treesitter.language')
044.132  000.285  000.180: require('vim.treesitter.query')
044.339  000.206  000.206: require('vim.treesitter._range')
044.344  000.681  000.190: require('vim.treesitter.languagetree')
044.348  001.062  000.381: require('vim.treesitter')
044.543  000.194  000.194: require('vim.treesitter.highlighter')
044.648  000.103  000.103: require('treesitter-context.cache')
046.802  000.150  000.150: require('nvim-treesitter.compat')
047.652  000.426  000.426: require('nvim-treesitter.parsers')
047.737  000.084  000.084: require('nvim-treesitter.utils')
047.740  000.782  000.272: require('nvim-treesitter.ts_utils')
047.742  000.939  000.157: require('nvim-treesitter.tsrange')
047.828  000.086  000.086: require('nvim-treesitter.caching')
047.841  001.368  000.194: require('nvim-treesitter.query')
047.848  001.557  000.189: require('nvim-treesitter.configs')
047.849  002.069  000.512: require('nvim-treesitter-textobjects')
048.475  000.151  000.151: require('nvim-treesitter.info')
048.654  000.177  000.177: require('nvim-treesitter.shell_command_selectors')
048.663  000.517  000.189: require('nvim-treesitter.install')
048.745  000.081  000.081: require('nvim-treesitter.statusline')
048.962  000.216  000.216: require('nvim-treesitter.query_predicates')
048.964  001.114  000.299: require('nvim-treesitter')
049.437  000.149  000.149: require('nvim-treesitter.textobjects.shared')
049.439  000.472  000.323: require('nvim-treesitter.textobjects.select')
049.781  000.165  000.165: require('nvim-treesitter.textobjects.attach')
049.950  000.169  000.169: require('nvim-treesitter.textobjects.repeatable_move')
049.953  000.504  000.171: require('nvim-treesitter.textobjects.move')
050.149  000.125  000.125: require('nvim-treesitter.textobjects.swap')
050.992  000.832  000.832: require('nvim-treesitter.textobjects.lsp_interop')
051.019  005.735  000.620: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textobjects/plugin/nvim-treesitter-textobjects.vim
051.507  000.289  000.289: require('nvim-treesitter-textsubjects')
051.510  000.388  000.099: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-textsubjects/plugin/nvim-treesitter-textsubjects.vim
052.056  000.067  000.067: require('nvim-tree-docs.aniseed.autoload')
052.058  000.326  000.259: require('nvim-tree-docs.main')
052.062  000.424  000.098: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-tree-docs/plugin/nvim-tree-docs.vim
052.663  000.318  000.318: require('ts_context_commentstring')
052.664  000.411  000.093: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-context-commentstring/plugin/ts_context_commentstring.vim
053.044  000.261  000.261: require('nvim-treesitter-endwise')
053.046  000.303  000.041: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-endwise/plugin/nvim-treesitter-endwise.lua
054.053  000.060  000.060: require('nvim-ts-autotag._log')
054.054  000.136  000.076: require('nvim-ts-autotag.utils')
054.061  000.408  000.271: require('nvim-ts-autotag.internal')
054.062  000.661  000.254: require('nvim-ts-autotag')
054.064  000.748  000.087: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-autotag/plugin/nvim-ts-autotag.vim
054.598  000.270  000.270: require('rainbow')
054.604  000.361  000.090: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-ts-rainbow/plugin/rainbow.vim
055.229  000.485  000.485: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter/plugin/nvim-treesitter.lua
060.332  000.296  000.296: require('nvim-treesitter.highlight')
060.470  000.107  000.107: require('nvim-treesitter.endwise')
061.092  000.203  000.203: require('nvim-treesitter.locals')
061.095  000.512  000.309: require('nvim-treesitter.incremental_selection')
061.267  000.141  000.141: require('rainbow.internal')
061.569  000.214  000.214: require('nvim-treesitter.indent')
061.774  000.085  000.085: require('ts_context_commentstring.utils')
061.781  000.175  000.090: require('ts_context_commentstring.internal')
061.783  017.135  006.835: require('nvim-treesitter.parsers')
061.805  019.054  000.559: require('treesitter-context')
061.806  019.154  000.100: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/nvim-treesitter-context/plugin/treesitter-context.vim
063.747  000.343  000.343: require('Comment.config')
064.209  000.306  000.306: require('Comment.ft')
064.214  000.466  000.160: require('Comment.utils')
064.326  000.111  000.111: require('Comment.opfunc')
064.436  000.110  000.110: require('Comment.extra')
064.444  001.510  000.480: require('Comment.api')
064.518  001.740  000.230: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/Comment.nvim/plugin/Comment.lua
064.675  000.133  000.133: require('Comment')
065.353  000.282  000.282: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-endwise/plugin/endwise.vim
066.237  000.394  000.394: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-surround/plugin/surround.vim
066.809  000.259  000.259: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/auto-pairs/plugin/auto-pairs.vim
067.595  000.284  000.284: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/vim-tmux-navigator/plugin/tmux_navigator.vim
068.218  000.304  000.304: sourcing /Users/mitchell/.local/share/nj-nvim/lazy/CamelCaseMotion/plugin/camelcasemotion.vim
068.854  000.499  000.499: require('vim.filetype')
069.663  000.387  000.387: require('vim.filetype.detect')
070.459  000.169  000.169: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/ftplugin/elixir.vim
072.640  000.216  000.216: require('vim.uri')
231.745  000.343  000.343: require('rainbow.levels')
304.914  000.448  000.448: require('editorconfig')
306.093  000.231  000.231: sourcing /Users/mitchell/.asdf/installs/neovim/ref-master/share/nvim/runtime/autoload/provider/clipboard.vim
306.330  247.311: opening buffers
328.204  021.874: BufEnter autocommands
328.206  000.002: editing files in windows
328.322  000.117: VimEnter autocommands
328.344  000.021: UIEnter autocommands
328.346  000.002: before starting main loop
439.011  110.665: first screen update
439.012  000.002: --- NVIM STARTED ---


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.005  000.005: --- NVIM STARTING ---
000.057  000.052: event init
000.317  000.260: early init
000.707  000.390: locale set
000.745  000.038: init first window
000.973  000.228: inits 1
000.977  000.005: window checked
001.061  000.084: parsing arguments
001.347  000.035  000.035: require('vim.shared')
001.394  000.020  000.020: require('vim._meta')
001.395  000.046  000.026: require('vim._editor')
001.396  000.109  000.028: require('vim._init_packages')
001.397  000.227: init lua interpreter
001.570  000.173: expanding arguments
001.580  000.010: inits 2
001.755  000.175: init highlight
```

</p>
</details> 