### PR TITLE
Fix umbrella app detection

### DIFF
--- a/lua/elixir/utils.lua
+++ b/lua/elixir/utils.lua
@@ -16,20 +16,10 @@ function M.root_dir(fname)
     fname = vim.fn.getcwd()
   end
 
-  local child_or_root_path =
-    vim.fs.dirname(vim.fs.find({ "mix.exs", ".git" }, { upward = true, path = fname })[1])
-  local maybe_umbrella_path =
-    vim.fs.dirname(vim.fs.find({ "mix.exs" }, { upward = true, path = child_or_root_path })[1])
+  local matches = vim.fs.find({ "mix.exs" }, { upward = true, limit = 2, path = fname })
+  local child_or_root_path, maybe_umbrella_path = unpack(matches)
 
-  if maybe_umbrella_path then
-    if not vim.startswith(child_or_root_path, Path:joinpath(maybe_umbrella_path, "apps"):absolute()) then
-      maybe_umbrella_path = nil
-    end
-  end
-
-  local path = maybe_umbrella_path or child_or_root_path or vim.loop.os_homedir()
-
-  return path
+  return vim.fs.dirname(maybe_umbrella_path or child_or_root_path)
 end
 
 return M

--- a/tests/fixtures/project_a/lib/module.ex
+++ b/tests/fixtures/project_a/lib/module.ex
@@ -1,0 +1,3 @@
+defmodule ProjectA.Module do
+
+end

--- a/tests/fixtures/project_a/mix.exs
+++ b/tests/fixtures/project_a/mix.exs
@@ -1,0 +1,4 @@
+defmodule ProjectA.MixProject do
+
+end
+

--- a/tests/fixtures/project_b/apps/app_a/lib/module.ex
+++ b/tests/fixtures/project_b/apps/app_a/lib/module.ex
@@ -1,0 +1,3 @@
+defmodule AppA.Module do
+
+end

--- a/tests/fixtures/project_b/apps/app_a/mix.exs
+++ b/tests/fixtures/project_b/apps/app_a/mix.exs
@@ -1,0 +1,4 @@
+defmodule AppA.MixProject do
+
+end
+

--- a/tests/fixtures/project_b/mix.exs
+++ b/tests/fixtures/project_b/mix.exs
@@ -1,0 +1,4 @@
+defmodule ProjectB.MixProject do
+
+end
+

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -1,0 +1,44 @@
+local root_dir = vim.fn.getcwd()
+local utils = require("elixir.utils")
+
+describe("utils", function()
+
+  after_each(function()
+    vim.api.nvim_command("cd " .. root_dir)
+  end)
+
+  describe("root_dir", function()
+
+    it("finds elixir project root dir without a filename", function()
+
+      local project_dir = root_dir .. "/tests/fixtures/project_a"
+
+      vim.api.nvim_command("cd " .. project_dir)
+      local result = utils.root_dir()
+
+      assert.are.equal(project_dir, result)
+    end)
+
+    it("finds elixir project root dir", function()
+      local project_dir = root_dir .. "/tests/fixtures/project_a"
+      local result = utils.root_dir(project_dir .. "/lib/module.ex")
+
+      assert.are.equal(project_dir, result)
+    end)
+
+    it("finds elixir umbrella project root dir", function()
+      local project_dir = root_dir .. "/tests/fixtures/project_b"
+      local result = utils.root_dir(project_dir .. "/apps/app_a/lib/module.ex")
+
+      assert.are.equal(project_dir, result)
+    end)
+
+    it("returns nil if no elixir project root dir is found", function()
+      local result = utils.root_dir()
+
+      assert.are.equal(nil, result)
+    end)
+
+  end)
+end)
+


### PR DESCRIPTION
This fixes umbrella path detection. Currently, `maybe_umbrella_path` is always the same as `child_or_root_path` because of how `vim.fs.find` works.
So this change kind of restores the logic that existed before removing [lspconfig dep](https://github.com/elixir-tools/elixir-tools.nvim/commit/aa75df6f1aa7bcccf8453c1d432bd5a7ebf682ec#diff-3d47136a879de930f74561d8e082d113c20cca7030680548d8c1bce9c0636ed1L26)

## Suggestion
It also removes the logic that detects if the umbrella path contains the dir `apps`. This was because this path could be set to another name in `mix. exs` with `:apps_path,` and maybe it is redundant checking for this when we found the `mix. exs` in a parent dir. But this is a suggestion, and I may be missing something.
