### PR TITLE
Gracefully handle latest_release check when offline

### DIFF
--- a/lua/elixir/init.lua
+++ b/lua/elixir/init.lua
@@ -40,7 +40,7 @@ function M.setup(opts)
     opts.credo.cmd = M.credo.default_bin
   end
 
-  if not opts.credo.version then
+  if enabled(opts.credo.enable) and not opts.credo.version then
     opts.credo.version = utils.latest_release("elixir-tools", "credo-language-server")
   end
 
@@ -48,7 +48,7 @@ function M.setup(opts)
     opts.nextls.cmd = M.nextls.default_bin
   end
 
-  if not opts.nextls.version then
+  if opts.nextls.enable and not opts.nextls.version then
     opts.nextls.version = utils.latest_release("elixir-tools", "next-ls")
   end
 
@@ -57,11 +57,12 @@ function M.setup(opts)
   if enabled(opts.elixirls.enable) then
     elixirls.setup(opts.elixirls)
   end
-  if enabled(opts.credo.enable) then
+
+  if opts.credo.version and enabled(opts.credo.enable) then
     credo.setup(opts.credo)
   end
 
-  if opts.nextls.enable == true then
+  if opts.nextls.version and opts.nextls.enable == true then
     nextls.setup(opts.nextls)
   end
 end

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -36,4 +36,35 @@ describe("utils", function()
       assert.are.equal(nil, result)
     end)
   end)
+
+  describe("latest_release", function()
+    it("returns the latest release for the repo", function()
+      local result = utils.latest_release("elixir-tools", "next-ls", { cache_dir = "./tmp/" })
+
+      assert(type(result) == "string")
+      assert.is.Truthy(string.match(result, "%d+%.%d+%.%d+"))
+    end)
+
+    it("returns nil if the command has a non zero exit code and no file in cache", function()
+      vim.fn.delete("./tmp/elixir-tools-next-ls.txt")
+      local result = utils.latest_release(
+        "elixir-tools",
+        "next-ls",
+        { github_host = "localhost:9999", cache_dir = "./tmp/" }
+      )
+
+      assert.is.Nil(result)
+    end)
+
+    it("returns nil if the command has a non zero exit code and no file in cache", function()
+      vim.fn.writefile({ "0.2.2" }, "./tmp/elixir-tools-next-ls.txt")
+      local result = utils.latest_release(
+        "elixir-tools",
+        "next-ls",
+        { github_host = "localhost:9999", cache_dir = "./tmp/" }
+      )
+
+      assert.are.same(result, "0.2.2")
+    end)
+  end)
 end)


### PR DESCRIPTION
Currently, if you attempt to start elixir-tools when offline, this error is generated:

```
Failed to run `config` for elixir.nvim
.../.local/share/nvim/lazy/elixir.nvim/lua/elixir/utils.lua:30: Expected value but found T_END at character 1
# stacktrace:
  - /elixir.nvim/lua/elixir/utils.lua:30 _in_ **latest_release**
  - /elixir.nvim/lua/elixir/init.lua:44 _in_ **setup**
  - ~/.config/nvim/lua/custom/plugins.lua:288 _in_ **config**
  - ~/brew/Cellar/neovim/0.9.1/share/nvim/runtime/filetype.lua:22
  - ~/brew/Cellar/neovim/0.9.1/share/nvim/runtime/filetype.lua:21
Press ENTER or type command to continue
```

With this change, if you attempt to start elixir-tools when offline, the following messages will instead be printed to the status line:

```
Failed request to Github to fetch version information for latest release of elixir-tools/credo-language-server
Failed request to Github to fetch version information for latest release of elixir-tools/next-ls
Client 1 quit with exit code 1 and signal 0
```