### PR TITLE
fix: elixir-tools fails to load when latest version check fails

### DIFF
--- a/lua/elixir/utils.lua
+++ b/lua/elixir/utils.lua
@@ -37,7 +37,7 @@ function M.latest_release(owner, repo, opts)
   local github_host = opts.github_host or "api.github.com"
   local cache_dir = opts.cache_dir or "~/.cache/nvim/elixir-tools.nvim/"
   local curl = string.format(
-    [[curl --silent -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://%s/repos/%s/%s/releases/latest]],
+    [[curl --fail --silent -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://%s/repos/%s/%s/releases/latest]],
     github_host,
     owner,
     repo
@@ -63,7 +63,10 @@ function M.latest_release(owner, repo, opts)
     vim.notify(
       "Failed to fetch the current "
         .. repo
-        .. " version from GitHub or the cache. You most likely do not have an internet connection and have no cached version of the language server."
+        .. " version from GitHub or the cache.\n"
+        .. "You most likely do not have an internet connection / exceeded\n"
+        .. "the GitHub rate limit, and have no cached version of the language\n"
+        .. "server."
     )
 
     return nil


### PR DESCRIPTION
# Motivation

elixir-tools.nvim fails to start if the latest version check fails with a non-200 status code (which happens in cases of a rate limit being reached)
![](https://user-images.githubusercontent.com/551858/257110619-222dfac2-6cde-4393-b145-3c6893b467af.png)


For full description see https://github.com/elixir-tools/elixir-tools.nvim/issues/150

For additional context this was happening to me when I was on a VPN. Since the unauthenticated rate limit relies on IP address, and there are many users on that server, I hit the limit of 60 reqs per hour. This can also happen to someone tweaking their config and re-opening NeoVim a bunch of times.

# Changes

This PR does two things:

- use the `--fail` switch in the `curl` command that checks the latest version.
  This makes the command return a non-zero status if the response status is not
  2xx.
- change the message so that it includes a note about a potential failure of the
  version check command due to the GitHub unauthenticated rate limit.

With these changes, elixir-tools is usable again, even if the rate limit call returns a non-2xx status code, as long as the user has a version of ElixirLS cached.

# Demo

With elixir-tools cache (no notifications and elixir-tools functions correctly):

https://github.com/elixir-tools/elixir-tools.nvim/assets/551858/f2cfdd14-6570-4c34-a73c-612126a5956a

With no elixir-tools cache:

https://github.com/elixir-tools/elixir-tools.nvim/assets/551858/b1272260-ad53-494b-8e97-443cfe5639b9

