### PR TITLE
fixup/x86-64_arch

### DIFF
--- a/lua/elixir/utils.lua
+++ b/lua/elixir/utils.lua
@@ -32,7 +32,7 @@ local arch = {
   ["arm64"] = "arm64",
   ["aarch64"] = "arm64",
   ["amd64"] = "amd64",
-  ["x86-64"] = "amd64",
+  ["x86_64"] = "amd64",
 }
 
 function M.download_nextls(opts)


### PR DESCRIPTION
I was getting a `failed to make nextls executable` error when attempting to install NextLS.

```
lua print(vim.uv.os_uname().machine)
```
produces the output `x86_64`