### PR TITLE
Fix typo in the vim help

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ elixir.setup {
 
 The language server for Elixir that just works. 😎
 
-You can read more about it at https://www.elixir-tools.dev/next-ls.
+You can read more about it at https://www.elixir-tools.dev/next-ls/
 
 ## Credo Language Server
 

--- a/doc/elixir-tools.nvim.txt
+++ b/doc/elixir-tools.nvim.txt
@@ -192,7 +192,7 @@ NEXT LS                                   *elixir-tools.nvim-features-next-ls*
   You’ll want to add that to your gitignore.
 The language server for Elixir that just works.
 
-You can read more about it at https://www.elixir-tools.dev/next-ls/
+Youcan read more about it at https://www.elixir-tools.dev/next-ls.
 
 
 CREDO LANGUAGE SERVER       *elixir-tools.nvim-features-credo-language-server*

--- a/doc/elixir-tools.nvim.txt
+++ b/doc/elixir-tools.nvim.txt
@@ -192,7 +192,7 @@ NEXT LS                                   *elixir-tools.nvim-features-next-ls*
   You’ll want to add that to your gitignore.
 The language server for Elixir that just works.
 
-Youcan read more about it at https://www.elixir-tools.dev/next-ls.
+You can read more about it at https://www.elixir-tools.dev/next-ls/
 
 
 CREDO LANGUAGE SERVER       *elixir-tools.nvim-features-credo-language-server*


### PR DESCRIPTION
Noticed those small typos while reading the help.