### PR TITLE
fix: activate nextls when it detects a mix.exs file

### DIFF
--- a/lua/elixir/credo/init.lua
+++ b/lua/elixir/credo/init.lua
@@ -11,7 +11,7 @@ function M.setup(opts)
     group = credo,
     pattern = { "elixir" },
     callback = function()
-      local matches = vim.fs.find({ "mix.lock", "mix.exs" }, {
+      local matches = vim.fs.find({ "mix.lock" }, {
         stop = vim.uv.os_homedir(),
         upward = true,
         path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),

--- a/lua/elixir/credo/init.lua
+++ b/lua/elixir/credo/init.lua
@@ -11,7 +11,7 @@ function M.setup(opts)
     group = credo,
     pattern = { "elixir" },
     callback = function()
-      local matches = vim.fs.find({ "mix.lock" }, {
+      local matches = vim.fs.find({ "mix.lock", "mix.exs" }, {
         stop = vim.uv.os_homedir(),
         upward = true,
         path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),

--- a/lua/elixir/nextls/init.lua
+++ b/lua/elixir/nextls/init.lua
@@ -49,7 +49,7 @@ function M.setup(opts)
     group = nextls_group,
     pattern = { "elixir", "eelixir", "heex", "surface" },
     callback = function()
-      local matches = vim.fs.find({ "mix.lock" }, {
+      local matches = vim.fs.find({ "mix.lock", "mix.exs" }, {
         stop = vim.uv.os_homedir(),
         upward = true,
         path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),


### PR DESCRIPTION
As for pure mix projects we don't have a mix.lock then the plugin needs another way to know that it's a elixir project to spin up lsp server