### PR TITLE
feat(nextls): init options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ elixir.setup {
     enable = false, -- defaults to false
     port = 9000, -- connect via TCP with the given port. mutually exclusive with `cmd`. defaults to nil
     cmd = "path/to/next-ls", -- path to the executable. mutually exclusive with `port`
+    init_options = {
+      mix_env = "dev",
+      mix_target = "host"
+    },
     on_attach = function(client, bufnr)
       -- custom keybinds
     end

--- a/lua/elixir/nextls/init.lua
+++ b/lua/elixir/nextls/init.lua
@@ -25,7 +25,7 @@ function M.setup(opts)
           NEXTLS_VERSION = options.version,
           NEXTLS_AUTO_UPDATE = auto_update,
         },
-        init_options = options.init_options or {},
+        init_options = options.init_options or vim.empty_dict(),
         settings = {},
         capabilities = options.capabilities or vim.lsp.protocol.make_client_capabilities(),
         workspace_folders = {

--- a/lua/elixir/nextls/init.lua
+++ b/lua/elixir/nextls/init.lua
@@ -25,6 +25,7 @@ function M.setup(opts)
           NEXTLS_VERSION = options.version,
           NEXTLS_AUTO_UPDATE = auto_update,
         },
+        init_options = options.init_options or {},
         settings = {},
         capabilities = options.capabilities or vim.lsp.protocol.make_client_capabilities(),
         workspace_folders = {


### PR DESCRIPTION
feat(nextls): init options

Next LS has support for passing configuring the default MIX_ENV and
MIX_TARGET of your project's runtime, and are accepted as init_options
