### PR TITLE
feat(nextls): multi-root workspaces

### DIFF
--- a/lua/elixir/iter/init.lua
+++ b/lua/elixir/iter/init.lua
@@ -84,14 +84,14 @@ end
 local packedmt = {}
 
 local function unpack(t)
-  if type(t) == 'table' and getmetatable(t) == packedmt then
+  if type(t) == "table" and getmetatable(t) == packedmt then
     return _G.unpack(t, 1, t.n)
   end
   return t
 end
 
 local function pack(...)
-  local n = select('#', ...)
+  local n = select("#", ...)
   if n > 1 then
     return setmetatable({ n = n, ... }, packedmt)
   end
@@ -99,7 +99,7 @@ local function pack(...)
 end
 
 local function sanitize(t)
-  if type(t) == 'table' and getmetatable(t) == packedmt then
+  if type(t) == "table" and getmetatable(t) == packedmt then
     -- Remove length tag
     t.n = nil
   end
@@ -448,7 +448,7 @@ end
 ---
 ---@return Iter
 function Iter.rev(self)
-  error('rev() requires a list-like table')
+  error("rev() requires a list-like table")
   return self
 end
 
@@ -479,7 +479,7 @@ end
 ---
 ---@return any
 function Iter.peek(self) -- luacheck: no unused args
-  error('peek() requires a list-like table')
+  error("peek() requires a list-like table")
 end
 
 ---@private
@@ -513,7 +513,7 @@ end
 ---
 ---@return any
 function Iter.find(self, f)
-  if type(f) ~= 'function' then
+  if type(f) ~= "function" then
     local val = f
     f = function(v)
       return v == val
@@ -560,12 +560,12 @@ end
 ---
 ---@return any
 function Iter.rfind(self, f) -- luacheck: no unused args
-  error('rfind() requires a list-like table')
+  error("rfind() requires a list-like table")
 end
 
 ---@private
 function ListIter.rfind(self, f) -- luacheck: no unused args
-  if type(f) ~= 'function' then
+  if type(f) ~= "function" then
     local val = f
     f = function(v)
       return v == val
@@ -599,7 +599,7 @@ end
 ---
 ---@return any
 function Iter.nextback(self) -- luacheck: no unused args
-  error('nextback() requires a list-like table')
+  error("nextback() requires a list-like table")
 end
 
 function ListIter.nextback(self)
@@ -628,7 +628,7 @@ end
 ---
 ---@return any
 function Iter.peekback(self) -- luacheck: no unused args
-  error('peekback() requires a list-like table')
+  error("peekback() requires a list-like table")
 end
 
 function ListIter.peekback(self)
@@ -686,7 +686,7 @@ end
 ---@param n number Number of values to skip.
 ---@return Iter
 function Iter.skipback(self, n) -- luacheck: no unused args
-  error('skipback() requires a list-like table')
+  error("skipback() requires a list-like table")
   return self
 end
 
@@ -760,7 +760,7 @@ end
 ---@param last number
 ---@return Iter
 function Iter.slice(self, first, last) -- luacheck: no unused args
-  error('slice() requires a list-like table')
+  error("slice() requires a list-like table")
   return self
 end
 
@@ -909,9 +909,9 @@ end
 ---@private
 function Iter.new(src, ...)
   local it = {}
-  if type(src) == 'table' then
+  if type(src) == "table" then
     local mt = getmetatable(src)
-    if mt and type(mt.__call) == 'function' then
+    if mt and type(mt.__call) == "function" then
       ---@private
       function it.next()
         return src()
@@ -937,7 +937,7 @@ function Iter.new(src, ...)
     return ListIter.new(t)
   end
 
-  if type(src) == 'function' then
+  if type(src) == "function" then
     local s, var = ...
 
     --- Use a closure to handle var args returned from iterator
@@ -957,7 +957,7 @@ function Iter.new(src, ...)
 
     setmetatable(it, Iter)
   else
-    error('src must be a table or function')
+    error("src must be a table or function")
   end
   return it
 end


### PR DESCRIPTION
This patch has a dependency on the https://github.com/mhanberg/workspace-folders.nvim plugin.

To try out the behavior, install that plugin and create a `.code-workspace` file that describes your multi-root workspace (or mono repo as most call it), in the root of your mono repo.

If your monorepo is called "money-factory-io", with the folders "crypto", "ai-chat-app", and "drop-shipping-cms", your `code-workspace` would be named `money-factory-io.code-workspace` and look like:

```json
{
  "folders": [
    {"path": "crypto"},
    {"path": "ai-chat-app"},
    {"path": "drop-shipping-cms"},
  ]
}
```
