### PR TITLE
fix: compile ElixirLS with Elixir v1.16

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,4 +9,4 @@ mix local.hex --force
 mix local.rebar --force
 mix deps.get
 mix compile
-mix elixir_ls.release -o "$release_path"
+mix elixir_ls.release2 -o "$release_path"

--- a/bin/compile
+++ b/bin/compile
@@ -9,4 +9,5 @@ mix local.hex --force
 mix local.rebar --force
 mix deps.get
 mix compile
+mkdir -p "$release_path"
 mix elixir_ls.release2 -o "$release_path"


### PR DESCRIPTION
Release mix task has been deprecated for some time and fails to work with Elixir v1.16. The recommended mix task is release2