### PR TITLE
feat(projectionist): allow disabling the projectionist integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,19 +96,19 @@ jobs:
           - os: ubuntu-20.04
             manager: sudo apt-get
             packages: -y fd-find esl-erlang elixir
-            nvim-version: 0.8.3
+            nvim-version: v0.8.3
           - os: ubuntu-20.04
             manager: sudo apt-get
             packages: -y fd-find esl-erlang elixir
-            nvim-version: 0.9.5
+            nvim-version: v0.9.5
           - os: macos-14
             manager: brew
             packages: fd elixir
-            nvim-version: 0.8.3
+            nvim-version: v0.8.3
           - os: macos-14
             manager: brew
             packages: fd elixir
-            nvim-version: 0.9.5
+            nvim-version: v0.9.5
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             manager: sudo apt-get
             packages: -y fd-find esl-erlang elixir
           - os: macos-14
-            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-x86_64.tar.gz
             manager: brew
             packages: fd elixir
           - os: macos-14

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Requires 0.8
           vim.keymap.set("n", "<space>tp", ":ElixirToPipe<cr>", { buffer = true, noremap = true })
           vim.keymap.set("v", "<space>em", ":ElixirExpandMacro<cr>", { buffer = true, noremap = true })
         end,
+      },
+      projectionist = {
+        enable = true
       }
     }
   end,
@@ -75,7 +78,7 @@ The minimal setup will configure both ElixirLS but not Next LS.
 require("elixir").setup()
 ```
 
-Next LS and ElixirLS can be enabled/disabled by setting the `enable` flag in the respective options table.
+Next LS, ElixirLS, and Projectionist can be enabled/disabled by setting the `enable` flag in the respective options table.
 
 The defaults are shown below.
 
@@ -83,6 +86,7 @@ The defaults are shown below.
 require("elixir").setup({
   nextls = {enable = false},
   elixirls = {enable = true},
+  projectionist = {enable = true},
 })
 ```
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ init: deps
   #!/usr/bin/env bash
   nvim-test/bin/nvim-test --init
 
-test nvim_version="0.9.5": init
+test nvim_version="v0.9.5": init
   #!/usr/bin/env bash
   nvim-test/bin/nvim-test --target_version {{nvim_version}} busted --lpath="$PWD/lua/?.lua"
 

--- a/lua/elixir/init.lua
+++ b/lua/elixir/init.lua
@@ -89,6 +89,7 @@ function M.setup(opts)
   opts.elixirls = opts.elixirls or {}
   opts.credo = opts.credo or {}
   opts.nextls = opts.nextls or {}
+  opts.projectionist = opts.projectionist or {}
 
   define_user_command()
 
@@ -107,7 +108,11 @@ function M.setup(opts)
   end
 
   mix.setup()
-  projectionist.setup()
+
+  if enabled(opts.projectionist.enable) then
+    projectionist.setup(opts.projectionist)
+  end
+
   if enabled(opts.elixirls.enable) then
     elixirls.setup(opts.elixirls)
   end

--- a/lua/elixir/projectionist/init.lua
+++ b/lua/elixir/projectionist/init.lua
@@ -225,7 +225,7 @@ local config = {
 function M.setup()
   local new_heuristics
   if vim.g.projectionist_heuristics then
-    new_heuristics = vim.tbl_extend("force", vim.g.projectionist_heuristics, config)
+    new_heuristics = vim.tbl_deep_extend("keep", vim.g.projectionist_heuristics, config)
   else
     new_heuristics = config
   end

--- a/tests/projectionist_spec.lua
+++ b/tests/projectionist_spec.lua
@@ -11,6 +11,30 @@ describe("projectionist", function()
 
   after_each(function()
     vim.cmd.cd("../../../")
+    vim.g.projectionist_heuristics = {}
+  end)
+
+  it("does not overwrite existing projections", function()
+    vim.g.projectionist_heuristics = {
+      ["mix.exs"] = {
+        ["lib/*_test.ex"] = {
+          type = "test",
+          alternate = "lib/{}.ex",
+        },
+      },
+    }
+
+    local test_projection_before_setup = vim.g.projectionist_heuristics["mix.exs"]["lib/*_test.ex"]
+
+    require("elixir.projectionist").setup()
+
+    local test_projection_after_setup = vim.g.projectionist_heuristics["mix.exs"]["lib/*_test.ex"]
+
+    -- existing projections not overwritten
+    assert.are.same(test_projection_before_setup, test_projection_after_setup)
+
+    -- new projections added
+    assert.not_nil(vim.g.projectionist_heuristics["mix.exs"]["lib/*.ex"])
   end)
 
   it("Eview", function()


### PR DESCRIPTION
# Motivation
> Why are we considering this change

Some projects are structured differently (I inherited a codebase that doesn't follow community conventions regarding directory structure).
If I try to overwrite the `projectionist_heuristics`, and the plugin is loaded after my changes, it wipes them out.

It would be great if there was a way to disable the projectionist integration for those of us who need to extend it.


# Summary of Changes
> A high level summary of what changed, including any important notes the reviewer should know

Main changes:
- adds a new user setting for disabling the projectionist integration
  - This change leaves the existing behavior of enabling it by default to prevent a breaking change for users.

Ancillary changes:
- Corrected a breaking change for nvim-test that broke the tests
  - See https://github.com/lewis6991/nvim-test/commit/94b485af0c63719097be95d3ef099f078b1be668

# Testing Instructions / Screenshots
> How can we confirm this PR is working as intended? Include any setup steps necessary

Setup `elixir-tools.nvim` with:

```lua
require("elixir").setup({
  projectionist = {enable = false},
})
```

Check that projections were not loaded by inspecting `vim.g.projectionist_heuristics`:

```lua
vim.inspect(vim.g.projectionist_heuristics)
```

https://github.com/elixir-tools/elixir-tools.nvim/assets/551858/3864070b-a20c-42ea-b17b-e4b888c7ad92


