### PR TITLE
fix: print elixirls repo if it fails to clone

### DIFF
--- a/lua/elixir/elixirls/download.lua
+++ b/lua/elixir/elixirls/download.lua
@@ -24,7 +24,7 @@ function M.clone(dir, opts)
 
   clone:sync(60000)
 
-  assert(clone.code == 0, "Failed to clone")
+  assert(clone.code == 0, string.format("Failed to clone %s", opts.repo))
 
   if opts.ref ~= "HEAD" then
     local checkout = Job:new {


### PR DESCRIPTION
I found it helpful to print the repo in the error message. It makes it easier to debug and fix a broken configuration.