### PR TITLE
fix: print dest directory if it fails to clone

### DIFF
--- a/lua/elixir/elixirls/download.lua
+++ b/lua/elixir/elixirls/download.lua
@@ -24,7 +24,7 @@ function M.clone(dir, opts)
 
   clone:sync(60000)
 
-  assert(clone.code == 0, string.format("Failed to clone %s", opts.repo))
+  assert(clone.code == 0, string.format("Failed to clone %s to %s", opts.repo, dir))
 
   if opts.ref ~= "HEAD" then
     local checkout = Job:new {


### PR DESCRIPTION
Help print more useful information when troubleshooting a broken git clone.