### PR TITLE
docs: correct Plug vimscript in README using " rather than '

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ use({ "elixir-tools/elixir-tools.nvim", tag = "stable", requires = { "nvim-lua/p
 ## vim-plug
 
 ```vimscript
-Plug "nvim-lua/plenary.nvim"
-Plug "elixir-tools/elixir-tools.nvim", { "tag": "stable" }
+Plug 'nvim-lua/plenary.nvim'
+Plug 'elixir-tools/elixir-tools.nvim', { 'tag': 'stable' }
 ```
 
 # Getting Started


### PR DESCRIPTION
In vimscript, using the `"` here is interpreted as starting a comment rather than delimiting a string.

So I get the following error when copying those two lines as is:
```
E471: Argument required:   Plug
```